### PR TITLE
Update NYTPhotoDismissalInteractionController.m

### DIFF
--- a/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
+++ b/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
@@ -35,7 +35,7 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
     CGFloat backgroundAlpha = [self backgroundAlphaForPanningWithVerticalDelta:verticalDelta];
     fromView.backgroundColor = [fromView.backgroundColor colorWithAlphaComponent:backgroundAlpha];
     
-    if (panGestureRecognizer.state == UIGestureRecognizerStateEnded) {
+    if (panGestureRecognizer.state == UIGestureRecognizerStateEnded || panGestureRecognizer.state == UIGestureRecognizerStateCancelled) {
         [self finishPanWithPanGestureRecognizer:panGestureRecognizer verticalDelta:verticalDelta viewToPan:viewToPan anchorPoint:anchorPoint];
     }
 }


### PR DESCRIPTION
Fixes issue, when you trying to dismiss NYTPhotoViewer (being landscape), which presented by portrait-only controller.
In that case panGestureRecognizer.state turns to "cancelled". We should treat that state the same way as "ended", because by the fact it ended.

Probably, there can be many other cases, which will be fix by this line of code.

Can be reproduced: 
iOS >= 8.0

I can provide video with "steps to reproduce", if you need this.
